### PR TITLE
Switch LR schedule to warmup-stable decay

### DIFF
--- a/config/train_nano_dense.py
+++ b/config/train_nano_dense.py
@@ -24,9 +24,10 @@ block_size = 512
 gradient_accumulation_steps = 1
 
 # epoch-based training
-max_epochs = 10
+num_epochs = 10.0
 evals_per_epoch = 20
-#stop_epoch = 3 
+warmup_frac = 0.01
+decay_frac = 0.1
 
 # eval stuff
 eval_iters = 100

--- a/config/train_nano_moe.py
+++ b/config/train_nano_moe.py
@@ -35,8 +35,10 @@ block_size = 512
 gradient_accumulation_steps = 2
 
 # epoch-based training
-max_epochs = 1
+num_epochs = 1.0
 evals_per_epoch = 50
+warmup_frac = 0.01
+decay_frac = 0.1
 
 # eval stuff
 eval_iters = 200


### PR DESCRIPTION
## Summary
- implement warmup/stable/decay learning rate schedule
- support fractional epochs with `num_epochs`
- update dataloader epoch configuration printouts
- update example configs to use new schedule parameters

## Testing
- `python -m py_compile train.py`
- `python -m py_compile config/train_nano_moe.py config/train_nano_dense.py`


------
https://chatgpt.com/codex/tasks/task_e_6869efc373208323a4354ee781ab94f7